### PR TITLE
Issue 21: Add a way to get from the generated pages back to home page

### DIFF
--- a/LennahSSG/FileReader.cpp
+++ b/LennahSSG/FileReader.cpp
@@ -8,7 +8,7 @@
  * 
  * returns the name of the newly generated html file
  */
-string FileReader::convertFile(string input, string output, int fileType)
+string FileReader::convertFile(string input, string output, int fileType, bool isFolder)
 {
     Formatter format;
     string title, line;
@@ -61,8 +61,10 @@ string FileReader::convertFile(string input, string output, int fileType)
         outputFile << "</title>\n"
             << "<meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">\n"
             << "</head>\n"
-            << "<body>\n"
-            << "<a href=\"index.html\">Home Page</a>\n";
+            << "<body>\n";
+
+        if (isFolder)
+            outputFile << "<a href=\"index.html\">Home Page</a>\n";
 
         outputFile << "<h1>" << title << "</h1>\n";
 

--- a/LennahSSG/FileReader.h
+++ b/LennahSSG/FileReader.h
@@ -9,6 +9,6 @@ using namespace std;
 class FileReader
 {
 public:
-	string convertFile(string input, string output, int fileType);
+	string convertFile(string input, string output, int fileType, bool isFolder);
 };
 

--- a/LennahSSG/LennahSSG.cpp
+++ b/LennahSSG/LennahSSG.cpp
@@ -88,14 +88,14 @@ void inputManager(string input, string output)
         cout << "Converting: " << input << endl;
         cout << "Outputting to: " << output << endl;
         fileType = 1;
-        reader.convertFile(input, output, fileType);
+        reader.convertFile(input, output, fileType, false);
     }
     else if (input.find(".md") != string::npos)
     {
         cout << "Converting: " << input << endl;
         cout << "Outputting to: " << output << endl;
         fileType = 2;
-        reader.convertFile(input, output, fileType);
+        reader.convertFile(input, output, fileType, false);
     }
     else
     {
@@ -110,13 +110,13 @@ void inputManager(string input, string output)
                 {
                     cout << "Converting: " << path << endl;
                     fileType = 1;
-                    generatedHTMLs.push_back(reader.convertFile(path, output, fileType));
+                    generatedHTMLs.push_back(reader.convertFile(path, output, fileType, true));
                 }
                 else if (path.find(".md") != string::npos)
                 {
                     cout << "Converting: " << path << endl;
                     fileType = 2;
-                    generatedHTMLs.push_back(reader.convertFile(path, output, fileType));
+                    generatedHTMLs.push_back(reader.convertFile(path, output, fileType, true));
                 }
             }
         }


### PR DESCRIPTION
Fixes  #21

For now it is fixed by adding a link at the top of generated pages that goes to index.html.
The link will only appear when the input is a folder, meaning it will only show up when there are supposedly multiple generated html files.

This was done by modifying the `convertFile()` to accept a bool to check if the input was a folder.